### PR TITLE
Fix copyrights

### DIFF
--- a/ac.soton.eventb.scenariochecker.branding/about.properties
+++ b/ac.soton.eventb.scenariochecker.branding/about.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.branding/build.properties
+++ b/ac.soton.eventb.scenariochecker.branding/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.branding/plugin.properties
+++ b/ac.soton.eventb.scenariochecker.branding/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.scenariochecker.doc/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: ac.soton.eventb.scenariochecker.doc;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.0.release
 Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.help;bundle-version="[3.8.800,4.0.0)"

--- a/ac.soton.eventb.scenariochecker.doc/OSGI-INF/l10n/bundle.properties
+++ b/ac.soton.eventb.scenariochecker.doc/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/build.properties
+++ b/ac.soton.eventb.scenariochecker.doc/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/html/eclipse-index.xml
+++ b/ac.soton.eventb.scenariochecker.doc/html/eclipse-index.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
 <!--
-    Copyright (c) 2011, 2020 University of Southampton.
+    Copyright (c) 2019, 2020 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/html/eclipse-plugin.xml
+++ b/ac.soton.eventb.scenariochecker.doc/html/eclipse-plugin.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
 <!--
-    Copyright (c) 2011, 2020 University of Southampton.
+    Copyright (c) 2019, 2020 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/html/eclipse-toc.xml
+++ b/ac.soton.eventb.scenariochecker.doc/html/eclipse-toc.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
 <!--
-    Copyright (c) 2011, 2021 University of Southampton.
+    Copyright (c) 2019, 2021 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/html/javahelp1-toc.xml
+++ b/ac.soton.eventb.scenariochecker.doc/html/javahelp1-toc.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
 <!--
-    Copyright (c) 2011, 2021 University of Southampton.
+    Copyright (c) 2019, 2021 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/html/javahelp2-toc.xml
+++ b/ac.soton.eventb.scenariochecker.doc/html/javahelp2-toc.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ISO-8859-1' ?>
 <!--
-    Copyright (c) 2011, 2021 University of Southampton.
+    Copyright (c) 2019, 2021 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/latex/plastex.sh
+++ b/ac.soton.eventb.scenariochecker.doc/latex/plastex.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #*******************************************************************************
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.doc/plugin.xml
+++ b/ac.soton.eventb.scenariochecker.doc/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <!--
-    Copyright (c) 2011, 2020 University of Southampton.
+    Copyright (c) 2019, 2020 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.feature/build.properties
+++ b/ac.soton.eventb.scenariochecker.feature/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.feature/feature.properties
+++ b/ac.soton.eventb.scenariochecker.feature/feature.properties
@@ -49,7 +49,7 @@ Release history:\n\
 ### 0.0.0 ###First prototype release\n\
 
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2019-2021 University of Southampton. All rights reserved.
+featureCopyright=Copyright (c) 2019, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - label for the update site
 updateSiteName=Soton Plug-ins

--- a/ac.soton.eventb.scenariochecker.feature/feature.properties
+++ b/ac.soton.eventb.scenariochecker.feature/feature.properties
@@ -1,10 +1,15 @@
 ###############################################################################
-# Copyright (c) 2019-2021 University of Southampton
-# and others.
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the Eclipse Public License v1.0
+# Copyright (c) 2019, 2021 University of Southampton.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#    University of Southampton - initial API and implementation
 ###############################################################################
 # feature.properties
 # contains externalized strings for feature.xml

--- a/ac.soton.eventb.scenariochecker.feature/feature.properties
+++ b/ac.soton.eventb.scenariochecker.feature/feature.properties
@@ -31,8 +31,9 @@ Release history:\n\
 -------------------------------------------------------------------\n\
 ### 1.0.0 ###\n\
   scenariochecker (1.0.0) 	\n\
-  		-	improve pop-up menu (contribute to new animation support menu
-  		- 	fix problem stopping change of perspective
+  		-	fix copyrights\n\
+  		-	improve pop-up menu (contribute to new animation support menu)\n\
+  		- 	fix problem stopping change of perspective\n\
 		- 	fix some problems causing unreliable starting\n\
 		-	improve some rendering issues with control panel and state viewer\n\
 		-	change perspective icon to work in dark mode and differ from animation icon\n\

--- a/ac.soton.eventb.scenariochecker.feature/feature.xml
+++ b/ac.soton.eventb.scenariochecker.feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2021 University of Southampton.
+    Copyright (c) 2019, 2021 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0
@@ -42,9 +42,9 @@
       <import plugin="org.eventb.emf.persistence" version="3.0.0" match="compatible"/>
       <import plugin="ac.soton.eventb.emf.oracle" version="1.0.0" match="compatible"/>
       <import plugin="org.eclipse.ui.forms" version="3.7.1" match="compatible"/>
-      <import plugin="ac.soton.eventb.probsupport" version="0.0.1" match="compatible"/>
       <import plugin="org.rodinp.core" version="1.7.1" match="compatible"/>
       <import plugin="org.eclipse.help" version="3.8.800" match="compatible"/>
+      <import plugin="ac.soton.eventb.probsupport" version="0.0.0" match="compatible"/>
    </requires>
 
    <plugin

--- a/ac.soton.eventb.scenariochecker.feature/feature.xml
+++ b/ac.soton.eventb.scenariochecker.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ac.soton.eventb.scenariochecker.feature"
       label="%featureName"
-      version="1.0.0.qualifier"
+      version="1.0.0.release"
       provider-name="%featureVendor"
       plugin="ac.soton.eventb.scenariochecker.branding"
       license-feature="org.rodinp.licence"

--- a/ac.soton.eventb.scenariochecker.releng/pom.xml
+++ b/ac.soton.eventb.scenariochecker.releng/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2011, 2021 University of Southampton.
+    Copyright (c) 2019, 2021 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.sdk/build.properties
+++ b/ac.soton.eventb.scenariochecker.sdk/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.sdk/feature.properties
+++ b/ac.soton.eventb.scenariochecker.sdk/feature.properties
@@ -33,7 +33,7 @@ Release history:\n\
 - Scenario Checker Source Feature (0.0.0): Generated\n\
 
 # "copyright" property - copyright of the feature
-featureCopyright=Copyright (c) 2020-2021 University of Southampton. All rights reserved.
+featureCopyright=Copyright (c) 2020, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
 updateSiteName=Soton Plug-ins

--- a/ac.soton.eventb.scenariochecker.sdk/feature.xml
+++ b/ac.soton.eventb.scenariochecker.sdk/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 University of Southampton.
+    Copyright (c) 2019, 2020 University of Southampton.
    
     This program and the accompanying materials
     are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker.sdk/feature.xml
+++ b/ac.soton.eventb.scenariochecker.sdk/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="ac.soton.eventb.scenariochecker.sdk"
       label="%featureName"
-      version="1.0.0.qualifier"
+      version="1.0.0.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ac.soton.eventb.scenariochecker/META-INF/MANIFEST.MF
+++ b/ac.soton.eventb.scenariochecker/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-SymbolicName: ac.soton.eventb.scenariochecker;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.0.release
 Bundle-Activator: ac.soton.eventb.scenariochecker.Activator
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.ui;bundle-version="[3.7.0,4.0.0)",

--- a/ac.soton.eventb.scenariochecker/build.properties
+++ b/ac.soton.eventb.scenariochecker/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2020 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/plugin.properties
+++ b/ac.soton.eventb.scenariochecker/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 University of Southampton.
+# Copyright (c) 2019, 2021 University of Southampton.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Clock.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Clock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/OracleHandler.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/OracleHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Playback.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Playback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Triplet.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Triplet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Utils.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/Utils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/handlers/ScenarioCheckerHandler.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/handlers/ScenarioCheckerHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2021 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/participants/ScenarioCheckerParticipant.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/participants/ScenarioCheckerParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/perspectives/ScenarioCheckerPerspective.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/perspectives/ScenarioCheckerPerspective.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/AbstractScenarioCheckerView.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/AbstractScenarioCheckerView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/ScenarioCheckerControlPanelView.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/ScenarioCheckerControlPanelView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/ScenarioCheckerStateView.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/internal/scenariochecker/views/ScenarioCheckerStateView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/Activator.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/IScenarioCheckerView.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/IScenarioCheckerView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/Mode.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/Mode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 University of Southampton.
+ * Copyright (c) 2019, 2020 University of Southampton.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/ScenarioCheckerManager.java
+++ b/ac.soton.eventb.scenariochecker/src/ac/soton/eventb/scenariochecker/ScenarioCheckerManager.java
@@ -1,12 +1,15 @@
 /*******************************************************************************
- *  Copyright (c) 2019-2021 University of Southampton.
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  which accompanies this distribution, and is available at
- *  http://www.eclipse.org/legal/epl-v10.html
- *   
- *  Contributors:
- *  University of Southampton - Initial implementation
+ * Copyright (c) 2019, 2021 University of Southampton.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    University of Southampton - initial API and implementation
  *******************************************************************************/
 
 package ac.soton.eventb.scenariochecker;


### PR DESCRIPTION
apart from updating some to EPL v2.0 the start year for scenario checker should be 2019 at earliest (not 2011 which is the default in the copyright tool)